### PR TITLE
Can get cached bitcoin balances and block info from CoreBitcoin (Issue #98)

### DIFF
--- a/core/core-bitcoin.js
+++ b/core/core-bitcoin.js
@@ -116,11 +116,7 @@ CoreBitcoin.prototype.asyncUpdateBalance = function () {
       addressStrings.push(yield CryptoWorkers.asyncAddressStringFromAddress(addresses[i]))
     }
     let obj = yield this.blockchainAPI.asyncGetAddressesBalancesSatoshis(addresses)
-    if (obj.confirmedBalanceSatoshis !== this.balances.confirmedBalanceSatoshis ||
-        obj.unconfirmedBalanceSatoshis !== this.balances.unconfirmedBalanceSatoshis ||
-        obj.totalBalanceSatoshis !== this.balances.totalBalanceSatoshis) {
-      this.emit('balance', obj)
-    }
+    this.emit('balance', obj)
     this.balances = obj
   }, this)
 }
@@ -153,6 +149,7 @@ CoreBitcoin.prototype.asyncBuildTransaction = function (toAddress, toAmountSatos
       txb.from(obj.txhashbuf, obj.txoutnum, obj.txout, obj.pubkey)
     })
     txb.to(BN(toAmountSatoshis), toAddress)
+
     txb.build()
     return txb
   }, this)

--- a/core/core-bitcoin.js
+++ b/core/core-bitcoin.js
@@ -142,19 +142,26 @@ CoreBitcoin.prototype.getLastBalances = function () {
   return this.balances
 }
 
-CoreBitcoin.prototype.asyncGetLatestBlockInfo = function () {
+CoreBitcoin.prototype.asyncUpdateBlockInfo = function () {
   return asink(function *() {
     let blockInfo = yield this.blockchainAPI.asyncGetLatestBlockInfo()
 
     let blockInfoFound = blockInfo && blockInfo.hashbuf
     let blockChanged = blockInfoFound && (!this.lastBlockInfo || !this.lastBlockInfo.hashbuf || this.lastBlockInfo.hashbuf.toString('hex') !== blockInfo.hashbuf.toString('hex'))
 
+    this.lastBlockInfo = blockInfo
+
     if (blockChanged) {
       this.emit('block-info', blockInfo)
     }
 
-    this.lastBlockInfo = blockInfo
     return blockInfo
+  }, this)
+}
+
+CoreBitcoin.prototype.asyncGetLatestBlockInfo = function () {
+  return asink(function *() {
+    return this.asyncUpdateBlockInfo()
   }, this)
 }
 

--- a/core/index.js
+++ b/core/index.js
@@ -191,6 +191,10 @@ DattCore.prototype.asyncGetUserMnemonic = function () {
   return Promise.resolve(this.coreuser.user.mnemonic)
 }
 
+DattCore.prototype.getLastBalances = function () {
+  return this.corebitcoin.getLastBalances()
+}
+
 /**
  * Bitcoin
  * -------
@@ -212,6 +216,7 @@ DattCore.prototype.asyncBuildSignAndSendTransaction = function (toAddress, toAmo
 
 DattCore.prototype.monitorCoreBitcoin = function () {
   this.corebitcoin.on('balance', this.handleBitcoinBalance.bind(this))
+  this.corebitcoin.on('block-info', this.handleBlockInfo.bind(this))
   return this
 }
 
@@ -220,13 +225,25 @@ DattCore.prototype.handleBitcoinBalance = function (obj) {
   return this
 }
 
+DattCore.prototype.handleBlockInfo = function (obj) {
+  this.emit('bitcoin-block-info', obj)
+  return this
+}
+
 /**
  * Return information about the latest block, including the id and height.
- * TODO: Make this actually return the latest block info instead of a
- * pre-programmed value.
  */
 DattCore.prototype.asyncGetLatestBlockInfo = function () {
   return this.corebitcoin.asyncGetLatestBlockInfo()
+}
+
+/**
+ * Return cached info for last block if available
+ * Will return undefined if called before the first call of CoreBitcoin#asyncGetLatestBlockInfo
+ * Just for cases where you need to show something immediately and update after
+ */
+DattCore.prototype.getLastBlockInfo = function () {
+  return this.corebitcoin.getLastBlockInfo()
 }
 
 DattCore.prototype.asyncGetExtAddress = function (index) {

--- a/react/box-bitcoin.jsx
+++ b/react/box-bitcoin.jsx
@@ -49,7 +49,16 @@ let BoxBitcoin = React.createClass({
 
   monitorDattCore: function () {
     let dattcore = this.props.dattcore
+    let initBalances = dattcore.getLastBalances()
+    if (initBalances) {
+      this.handleBitcoinBalance(initBalances)
+    }
+    let initBlockInfo = dattcore.getLastBlockInfo()
+    if (initBlockInfo) {
+      this.handleBlockInfo(initBlockInfo)
+    }
     dattcore.on('bitcoin-balance', this.handleBitcoinBalance)
+    dattcore.on('bitcoin-block-info', this.handleBlockInfo)
   },
 
   handleBitcoinBalance: function (obj) {
@@ -61,6 +70,14 @@ let BoxBitcoin = React.createClass({
       unconfirmedBalanceBits,
       confirmedBalanceBits,
       totalBalanceBits})
+  },
+
+  handleBlockInfo: function (info) {
+    if (info && info.height && info.height !== this.state.blockheightnum) {
+      this.setState({
+        blockheightnum: info.height
+      })
+    }
   },
 
   handleReceive: function () {

--- a/react/box-bitcoin.jsx
+++ b/react/box-bitcoin.jsx
@@ -36,6 +36,18 @@ let BoxBitcoin = React.createClass({
   },
 
   componentWillMount: function () {
+    let dattcore = this.props.dattcore
+
+    let initBalances = dattcore.getLastBalances()
+    if (initBalances) {
+      this.handleBitcoinBalance(initBalances)
+    }
+
+    let initBlockInfo = dattcore.getLastBlockInfo()
+    if (initBlockInfo) {
+      this.handleBlockInfo(initBlockInfo)
+    }
+
     this.monitorDattCore()
   },
 
@@ -49,14 +61,7 @@ let BoxBitcoin = React.createClass({
 
   monitorDattCore: function () {
     let dattcore = this.props.dattcore
-    let initBalances = dattcore.getLastBalances()
-    if (initBalances) {
-      this.handleBitcoinBalance(initBalances)
-    }
-    let initBlockInfo = dattcore.getLastBlockInfo()
-    if (initBlockInfo) {
-      this.handleBlockInfo(initBlockInfo)
-    }
+
     dattcore.on('bitcoin-balance', this.handleBitcoinBalance)
     dattcore.on('bitcoin-block-info', this.handleBlockInfo)
   },

--- a/test/core/core-bitcoin.js
+++ b/test/core/core-bitcoin.js
@@ -325,22 +325,35 @@ describe('CoreBitcoin', function () {
     })
   })
 
-  describe('#asyncGetLatestBlockInfo', function () {
+  describe('#asyncUpdateBlockInfo', function () {
     it('should call blockchainAPI.asyncGetLatestBlockInfo', function () {
       return asink(function *() {
+        this.timeout(10000)
         let corebitcoin = CoreBitcoin()
         corebitcoin.blockchainAPI.asyncGetLatestBlockInfo = sinon.spy()
         yield corebitcoin.asyncGetLatestBlockInfo()
         corebitcoin.blockchainAPI.asyncGetLatestBlockInfo.calledOnce.should.equal(true)
-      })
+      }, this)
     })
 
     it('should emit event "block-info" on CoreBitcoin', function () {
       return asink(function *() {
+        this.timeout(10000)
         let corebitcoin = CoreBitcoin()
         corebitcoin.emit = sinon.spy()
         yield corebitcoin.asyncGetLatestBlockInfo()
         corebitcoin.emit.calledWith('block-info').should.equal(true)
+      }, this)
+    })
+  })
+
+  describe('#asyncGetLatestBlockInfo', function () {
+    it('should call #asyncUpdateBlockInfo', function () {
+      return asink(function *() {
+        let corebitcoin = CoreBitcoin()
+        corebitcoin.asyncUpdateBlockInfo = sinon.spy()
+        yield corebitcoin.asyncGetLatestBlockInfo()
+        corebitcoin.asyncUpdateBlockInfo.calledOnce.should.equal(true)
       })
     })
   })

--- a/test/core/core-bitcoin.js
+++ b/test/core/core-bitcoin.js
@@ -344,4 +344,25 @@ describe('CoreBitcoin', function () {
       })
     })
   })
+
+  describe('#getLastBlockInfo', function () {
+    it('if no block has been retrieved, it should return null', function () {
+      let corebitcoin = CoreBitcoin()
+
+      let lastBlockInfo = corebitcoin.getLastBlockInfo()
+
+      should(lastBlockInfo).not.be.ok()
+    })
+
+    it('should return the last block retrieved', function () {
+      return asink(function *() {
+        let corebitcoin = CoreBitcoin()
+
+        let retrievedBlockInfo = yield corebitcoin.asyncGetLatestBlockInfo()
+        let cachedBlockInfo = corebitcoin.getLastBlockInfo()
+
+        retrievedBlockInfo.should.equal(cachedBlockInfo)
+      })
+    })
+  })
 })

--- a/test/core/core-bitcoin.js
+++ b/test/core/core-bitcoin.js
@@ -334,5 +334,14 @@ describe('CoreBitcoin', function () {
         corebitcoin.blockchainAPI.asyncGetLatestBlockInfo.calledOnce.should.equal(true)
       })
     })
+
+    it('should emit event "block-info" on CoreBitcoin', function () {
+      return asink(function *() {
+        let corebitcoin = CoreBitcoin()
+        corebitcoin.emit = sinon.spy()
+        yield corebitcoin.asyncGetLatestBlockInfo()
+        corebitcoin.emit.calledWith('block-info').should.equal(true)
+      })
+    })
   })
 })

--- a/test/core/core-bitcoin.js
+++ b/test/core/core-bitcoin.js
@@ -82,6 +82,44 @@ describe('CoreBitcoin', function () {
     })
   })
 
+  describe('#getLastBalances', function () {
+    it('if no balances have been retrieved remotely, it should return default balances obj from CoreBitcoin#initialize', function () {
+      let corebitcoin = CoreBitcoin()
+
+      let cachedBalances = corebitcoin.getLastBalances()
+
+      should.exist(cachedBalances)
+
+      cachedBalances.should.be.an.instanceOf(Object)
+      cachedBalances.should.have.property('confirmedBalanceSatoshis', 0)
+      cachedBalances.should.have.property('unconfirmedBalanceSatoshis', 0)
+      cachedBalances.should.have.property('totalBalanceSatoshis', 0)
+    })
+
+    it('should return the last balances retrieved', function () {
+      return asink(function *() {
+        let mockBalances = {
+          confirmedBalanceSatoshis: 100,
+          unconfirmedBalanceSatoshis: 0,
+          totalBalanceSatoshis: 100
+        }
+
+        let corebitcoin = CoreBitcoin()
+
+        corebitcoin.asyncGetAllAddresses = () => Promise.resolve([])
+        corebitcoin.blockchainAPI = {
+          asyncGetAddressesBalancesSatoshis: sinon.stub().returns(Promise.resolve(mockBalances))
+        }
+
+        yield corebitcoin.asyncUpdateBalance()
+
+        let cachedBalances = corebitcoin.getLastBalances()
+
+        mockBalances.should.equal(cachedBalances)
+      })
+    })
+  })
+
   describe('#asyncBuildTransaction', function () {
     it('should create a txbuilder object from mocked data', function () {
       return asink(function *() {

--- a/test/core/core-bitcoin.js
+++ b/test/core/core-bitcoin.js
@@ -354,7 +354,7 @@ describe('CoreBitcoin', function () {
       should(lastBlockInfo).not.be.ok()
     })
 
-    it('should return the last block retrieved', function () {
+    it('should return the last block retrieved by #asyncGetLatestBlockInfo', function () {
       return asink(function *() {
         let corebitcoin = CoreBitcoin()
 

--- a/test/core/index.js
+++ b/test/core/index.js
@@ -275,4 +275,25 @@ describe('DattCore', function () {
       dattcore.corepeers.broadcastMsg.calledWith(msg).should.equal(true)
     })
   })
+
+  describe('#getLastBlockInfo', function () {
+    it('if no block has been retrieved, it should return null', function () {
+      let dattcore = DattCore({dbname: 'datt-temp'})
+
+      let lastBlockInfo = dattcore.getLastBlockInfo()
+
+      should(lastBlockInfo).not.be.ok()
+    })
+
+    it('should return the last block retrieved #asyncGetLatestBlockInfo', function () {
+      return asink(function *() {
+        let dattcore = DattCore({dbname: 'datt-temp'})
+
+        let retrievedBlockInfo = yield dattcore.asyncGetLatestBlockInfo()
+        let cachedBlockInfo = dattcore.getLastBlockInfo()
+
+        retrievedBlockInfo.should.equal(cachedBlockInfo)
+      })
+    })
+  })
 })


### PR DESCRIPTION
To address #98 

Makes it so CoreBitcoin issues "balance" events even if balance is unchanged whenever it checks the balance, to support stateless/new consumers.
