### PR TITLE
Content w/out address gets address from signing pubkey (Issue #99)

### DIFF
--- a/core/core-bitcoin.js
+++ b/core/core-bitcoin.js
@@ -190,6 +190,7 @@ CoreBitcoin.prototype.asyncSendTransaction = function (txb) {
 
 CoreBitcoin.prototype.asyncBuildSignAndSendTransaction = function (toAddress, toAmountSatoshis) {
   return asink(function *() {
+    // console.log('CoreBitcoin.prototype.asyncBuildSignAndSendTransaction(toAddress="'+toAddress+'",toAmountSatoshis="'+toAmountSatoshis+'")')
     let txb
     txb = yield this.asyncBuildTransaction(toAddress, toAmountSatoshis)
     txb = yield this.asyncSignTransaction(txb)

--- a/test/core/content-auth.js
+++ b/test/core/content-auth.js
@@ -56,6 +56,24 @@ describe('ContentAuth', function () {
     })
   })
 
+  describe('#setAddressFromPubkey', function () {
+    it('should derive and set an address from the provided public key using Address().fromPubkey', function () {
+      return asink(function *() {
+        let contentauth = ContentAuth().fromHex(contentauthhex)
+        let keypair = Keypair().fromRandom()
+        let pubkey = keypair.pubkey
+        let expectedAddress = Address().fromPubkey(pubkey)
+        let address = yield contentauth.setAddressFromPubkey(pubkey)
+        should.exist(address)
+        should.exist(address.hashbuf)
+        should.exist(contentauth.address)
+        should.exist(contentauth.address.hashbuf)
+        expectedAddress.hashbuf.toString('hex').should.equal(address.hashbuf.toString('hex'))
+        expectedAddress.hashbuf.toString('hex').should.equal(contentauth.address.hashbuf.toString('hex'))
+      })
+    })
+  })
+
   describe('#sign', function () {
     it('should sign this value and get the same thing back', function () {
       let contentauth = ContentAuth().fromHex(contentauthhex)
@@ -65,7 +83,7 @@ describe('ContentAuth', function () {
   })
 
   describe('#asyncSign', function () {
-    it('should resuld the same as #sign', function () {
+    it('should result the same as #sign', function () {
       return asink(function *() {
         let contentauth = ContentAuth().fromHex(contentauthhex)
         let sig = yield contentauth.asyncSign(keypair)


### PR DESCRIPTION
- This fixes issue #99 , where User announcement messages (generated by CoreUser#asyncGetMsgAuth) had an unspendable address associated with them
- Content without address (or with default unspendable NULL address) receives the address of the signing pubkey upon signing
- CoreUser#asyncGetMsgAuth uses ContentAuth#asyncSign instead of reimplementing the same signing logic
- ContentAuth has a new method #setAddressFromPubkey which also has a test
